### PR TITLE
Adds has-many relationship to content form

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
       tzinfo (~> 2.0)
     acts-as-taggable-on (9.0.1)
       activerecord (>= 6.0, < 7.1)
-    addressable (2.8.1)
+    addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
     amazing_print (1.4.0)
     aws-eventstream (1.2.0)
@@ -113,7 +113,7 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     bcrypt (3.1.18)
     builder (3.2.4)
-    capybara (3.38.0)
+    capybara (3.39.0)
       addressable
       matrix
       mini_mime (>= 0.1.3)
@@ -197,7 +197,7 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
-    nokogiri (1.14.2)
+    nokogiri (1.14.3)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     orm_adapter (0.5.0)
@@ -216,8 +216,8 @@ GEM
       pry (>= 0.10.4)
     public_suffix (5.0.1)
     racc (1.6.2)
-    rack (2.2.6.2)
-    rack-test (2.0.2)
+    rack (2.2.7)
+    rack-test (2.1.0)
       rack (>= 1.3)
     rails (7.0.4.2)
       actioncable (= 7.0.4.2)
@@ -248,7 +248,7 @@ GEM
     rake (13.0.6)
     redis-client (0.14.0)
       connection_pool
-    regexp_parser (2.7.0)
+    regexp_parser (2.8.0)
     responders (3.1.0)
       actionpack (>= 5.2)
       railties (>= 5.2)

--- a/app/assets/javascripts/cas/application.js
+++ b/app/assets/javascripts/cas/application.js
@@ -5,6 +5,57 @@
 //= require select2
 //= require_self
 
+/**
+ * Selectize is this lib that overrides <input> and makes them look like a set
+ * of tags, so you can add new values with autocompletion, and it's quite
+ * snappy.
+ */
+function initSelectize(element, options) {
+  let render = {}
+  /**
+   * In some cases, we want to allow the user to create new values. For example,
+   * when we have a list of tags, we want the user to be able to create new
+   * tags.
+   *
+   * In other cases, such as a list of has-many associations, we don't want the
+   * user creating new values.
+   */
+  if (options.canCreate) {
+    render = {
+      option_create: function(item, escape) {
+        var input = item.input;
+        return '<div class="create">' +
+          (input ? '<span class="caption">Criar <b>' + escape(input) + '</b></span>' : '') +
+          '</div>';
+      },
+    }
+  }
+
+  let params = {
+    plugins: ['restore_on_backspace', 'remove_button'],
+    delimiter: ',',
+    persist: true,
+    preload: false,
+    render: render,
+    onInitialize: function(){
+      var selectize = this;
+      var data = this.$input.data('autocomplete');
+      selectize.addOption(data);
+    }
+  }
+
+  if (options.canCreate) {
+    params["create"] = function(input) {
+      return {
+        value: input,
+        text: input
+      }
+    }
+  }
+
+  element.selectize(params);
+}
+
 $(document).ready(function() {
   $("#select-site").on("change", function(e) {
     var url = $(this).val();
@@ -13,31 +64,8 @@ $(document).ready(function() {
 
   $(".js-select2").select2();
 
-  $(".js-tags").selectize({
-    plugins: ['restore_on_backspace', 'remove_button'],
-    delimiter: ',',
-    persist: true,
-    preload: false,
-    render: {
-      option_create: function(item, escape) {
-        var input = item.input;
-        return '<div class="create">' +
-          (input ? '<span class="caption">Criar <b>' + escape(input) + '</b></span>' : '') +
-          '</div>';
-      },
-    },
-    create: function(input) {
-      return {
-        value: input,
-        text: input
-      }
-    },
-    onInitialize: function(){
-      var selectize = this;
-      var data = this.$input.data('autocomplete');
-      selectize.addOption(data);
-    }
-  });
+  initSelectize($(".js-tags"), { canCreate: true });
+  initSelectize($(".js-has-many-associations"), { canCreate: false });
 
   tinyMCE.init({
     branding: false,

--- a/app/assets/javascripts/cas/application.js
+++ b/app/assets/javascripts/cas/application.js
@@ -31,17 +31,22 @@ function initSelectize(element, options) {
     }
   }
 
+  let items = []
+  if (element && element.data('items')) {
+    items = element.data('items')
+  }
+
   let params = {
     plugins: ['restore_on_backspace', 'remove_button'],
     delimiter: ',',
     persist: true,
+    valueField: 'value',
+    labelField: 'text',
     preload: false,
     render: render,
-    onInitialize: function(){
-      var selectize = this;
-      var data = this.$input.data('autocomplete');
-      selectize.addOption(data);
-    }
+    highlight: true,
+    options: element.data('autocomplete'),
+    items: items
   }
 
   if (options.canCreate) {

--- a/app/controllers/cas/sites/sections/application_controller.rb
+++ b/app/controllers/cas/sites/sections/application_controller.rb
@@ -13,6 +13,7 @@ module Cas
       if !current_user.admin? && !current_user.editor?
         model_relation = model_relation.where(author_id: current_user.id)
       end
+
       model_relation
     end
 

--- a/app/controllers/cas/sites/sections/contents_controller.rb
+++ b/app/controllers/cas/sites/sections/contents_controller.rb
@@ -106,13 +106,21 @@ module Cas
           :embedded,
           :tag_list,
           :file,
-          content_to_content: [:cas_other_content_id]
+          :content_to_content
         )
 
-        result[:content_to_content] = Array.wrap(result[:content_to_content]).map { |json|
-            # content_json has { "cas_other_content_id": "some-id" }
-            Cas::ContentToContent.new(json)
+        if result[:content_to_content].present?
+          result[:content_to_content] = result[:content_to_content].split(",").map { |id|
+            # Params comes like this:
+            #
+            # {
+            #   content_to_content: "f0ba2d53-07ba-4e66-be76-edbcfc2559a5,7719b57e-fc23-45dc-8a42-faec74806b80"
+            # }
+            Cas::ContentToContent.new(cas_other_content_id: id)
           }
+        else
+          result[:content_to_content] = []
+        end
 
         unless result.keys.map(&:to_sym).include?(:published)
           result[:published] = true

--- a/app/helpers/cas/form_helper.rb
+++ b/app/helpers/cas/form_helper.rb
@@ -1,14 +1,28 @@
 module Cas
   module FormHelper
     def display_field?(name)
+      raise "No @section defined" if @section.blank?
       ::Cas::SectionConfig.new(@section).form_has_field?(name)
     end
 
     def form_associations
-      ::Cas::SectionConfig.new(@section).form_associations
+      raise "No @section defined" if @section.blank?
+      @form_associations ||= ::Cas::SectionConfig.new(@section).form_associations
+    end
+
+    def autocomplete_for_has_many
+      form_associations.each_with_object([]) { |association, memo|
+        slug = association.field_name
+        section = Cas::Section.where(slug: slug).pluck(:id, :name).first
+
+        Cas::Content.where(section_id: section[0]).pluck(:id, :title).each do |content|
+          memo << { value: content[0], text: "#{content[1]} (#{section[1]})" }
+        end
+      }
     end
 
     def field_properties(name)
+      raise "No @section defined" if @section.blank?
       ::Cas::FormField.new(@section, name)
     end
   end

--- a/app/views/cas/sites/sections/contents/_form_association.html.erb
+++ b/app/views/cas/sites/sections/contents/_form_association.html.erb
@@ -1,9 +1,0 @@
-<p>
-  <%= f.input :cas_other_content_id,
-    label: "#{association.label}:",
-    collection: @site.sections.find_by!(slug: association.field_name).contents.map { |content|
-      [content.title, content.id]
-    },
-    input_html: { class: 'js-select2' }
-  %>
-</p>

--- a/app/views/cas/sites/sections/contents/_form_for_content.html.erb
+++ b/app/views/cas/sites/sections/contents/_form_for_content.html.erb
@@ -21,7 +21,9 @@
     </p>
   <% end %>
 
-  <%= render 'form_has_many_associations', f: f %>
+  <% if form_associations.present? %>
+    <%= render 'form_has_many_associations', f: f %>
+  <% end %>
 
   <% if display_field?(:location) %>
     <p>

--- a/app/views/cas/sites/sections/contents/_form_for_content.html.erb
+++ b/app/views/cas/sites/sections/contents/_form_for_content.html.erb
@@ -21,12 +21,6 @@
     </p>
   <% end %>
 
-  <% form_associations.each do |association| %>
-    <% f.simple_fields_for :content_to_content do |rf| %>
-      <% # render 'form_association', f: rf, association: association %>
-    <% end %>
-  <% end %>
-
   <%= render 'form_has_many_associations', f: f %>
 
   <% if display_field?(:location) %>

--- a/app/views/cas/sites/sections/contents/_form_for_content.html.erb
+++ b/app/views/cas/sites/sections/contents/_form_for_content.html.erb
@@ -22,10 +22,12 @@
   <% end %>
 
   <% form_associations.each do |association| %>
-    <%= f.simple_fields_for :content_to_content do |rf| %>
-      <%= render 'form_association', f: rf, association: association %>
+    <% f.simple_fields_for :content_to_content do |rf| %>
+      <% # render 'form_association', f: rf, association: association %>
     <% end %>
   <% end %>
+
+  <%= render 'form_has_many_associations', f: f %>
 
   <% if display_field?(:location) %>
     <p>
@@ -46,7 +48,7 @@
   <% end %>
 
   <% if display_field?(:tags) %>
-    <% autocomplete = ActsAsTaggableOn::Tag.all.map { |t| {value: t.name, text: t.name} } %>
+    <% tags_autocomplete = ActsAsTaggableOn::Tag.all.map { |t| {value: t.name, text: t.name} } %>
     <%= f.input :tag_list,
       as: :string,
       required: false,
@@ -54,7 +56,7 @@
       input_html: {
         value: f.object.tag_list.join(", "),
         class: "js-tags",
-        data: { autocomplete: autocomplete.to_json }
+        data: { autocomplete: tags_autocomplete.to_json }
       }
     %>
   <% end %>

--- a/app/views/cas/sites/sections/contents/_form_has_many_associations.html.erb
+++ b/app/views/cas/sites/sections/contents/_form_has_many_associations.html.erb
@@ -1,0 +1,12 @@
+<p>
+  <%= f.input :content_to_content,
+    as: :string,
+    required: false,
+    label: "Associações",
+    input_html: {
+      value: f.object.related_contents.map { |content| content.title }.join(", "),
+      class: "js-has-many-associations",
+      data: { autocomplete: autocomplete_for_has_many.to_json }
+    }
+  %>
+</p>

--- a/app/views/cas/sites/sections/contents/_form_has_many_associations.html.erb
+++ b/app/views/cas/sites/sections/contents/_form_has_many_associations.html.erb
@@ -4,9 +4,16 @@
     required: false,
     label: "Associações",
     input_html: {
-      value: f.object.related_contents.map { |content| content.title }.join(", "),
+      # This value is replaced by selectize with whatever is in `data[items]`
+      # below, but it's useful for testing with Capybara.
+      value: f.object.related_contents.map { |content| content.id }.join(","),
       class: "js-has-many-associations",
-      data: { autocomplete: autocomplete_for_has_many.to_json }
+      data: {
+        autocomplete: autocomplete_for_has_many.to_json,
+        # These are the selected items. `selectize` will replace the value of
+        # the input with this array.
+        items: f.object.related_contents.map { |content| content.id }.to_json
+      }
     }
   %>
 </p>

--- a/docs/config.md
+++ b/docs/config.md
@@ -50,7 +50,6 @@ sites:
     domains:
       - mamarecipes.com
 
-
     # Config: global configuration across all sites
     config:
       # [optional]

--- a/lib/cas/section_config.rb
+++ b/lib/cas/section_config.rb
@@ -27,6 +27,7 @@ module Cas
   # To get a particular field, you can call
   #
   #   fields = load_section_config[1]["list_fields"]
+  #
   class SectionConfig
     def initialize(section)
       @section = section

--- a/spec/acceptance/contents_spec.rb
+++ b/spec/acceptance/contents_spec.rb
@@ -82,30 +82,39 @@ RSpec.feature 'Contents' do
         expect(content.tag_list).to match_array ['edited-tag1.1 edited-tag1.2', 'tag2']
       end
 
-      scenario "I edit a related section in a the news section" do
-        click_link "manage-section-#{section.id}"
-        click_link "edit-content-#{content.id}"
+      describe "associated content" do
+        scenario "I edit a related section in a the news section" do
+          click_link "manage-section-#{section.id}"
+          click_link "edit-content-#{content.id}"
 
-        # The YAML fixture has `biography` as a relation field in `news`
-        fill_in 'content_content_to_content', with: "#{biography1.id}"
+          input_value = "#{biography1.id}"
+          # The YAML fixture has `biography` as a relation field in `news`
+          fill_in 'content_content_to_content', with: input_value
 
-        expect(content.content_to_content.count).to eq(0)
-        click_on 'submit'
-        expect(content.content_to_content.reload.count).to eq(1)
-        expect(content.reload.related_contents).to eq([biography1])
-        expect(content.content_to_content.first!.related_section).to eq(biography_section)
+          expect(content.content_to_content.count).to eq(0)
+          click_on 'submit'
+          expect(content.content_to_content.reload.count).to eq(1)
+          expect(content.reload.related_contents).to eq([biography1])
+          expect(content.content_to_content.first!.related_section).to eq(biography_section)
 
-        # Asserting edited data
-        #
-        # Let's go back and make sure the new relationship is present in the
-        # form's select.
-        click_link "edit-content-#{content.id}"
-        fill_in 'content_content_to_content', with: "#{biography2.id},#{biography3.id}"
-        click_on 'submit'
+          # Asserting edited data
+          #
+          # Let's go back and make sure the new relationship is present in the
+          # form's select.
+          click_link "edit-content-#{content.id}"
+          expect(find('#content_content_to_content').value).to eq(input_value)
 
-        expect(content.content_to_content.reload.count).to eq(2)
-        expect(content.reload.related_contents).to eq([biography2, biography3])
-        expect(content.content_to_content.first!.related_section).to eq(biography_section)
+          input_value = "#{biography2.id},#{biography3.id}"
+          fill_in 'content_content_to_content', with: input_value
+          click_on 'submit'
+
+          expect(content.content_to_content.reload.count).to eq(2)
+          expect(content.reload.related_contents).to eq([biography2, biography3])
+          expect(content.content_to_content.first!.related_section).to eq(biography_section)
+
+          click_link "edit-content-#{content.id}"
+          expect(find('#content_content_to_content').value).to eq(input_value)
+        end
       end
 
       scenario "I edit the order of the images" do

--- a/spec/acceptance/contents_spec.rb
+++ b/spec/acceptance/contents_spec.rb
@@ -86,8 +86,7 @@ RSpec.feature 'Contents' do
         click_link "edit-content-#{content.id}"
 
         # The YAML fixture has `biography` as a relation field in `news`
-        expect(page).to have_content("Related biography")
-        select(biography1.title, from: "Related biography")
+        fill_in 'content_content_to_content', with: "#{biography1.id}"
 
         expect do
           click_on 'submit'
@@ -100,7 +99,7 @@ RSpec.feature 'Contents' do
         # Let's go back and make sure the new relationship is present in the
         # form's select.
         click_link "edit-content-#{content.id}"
-        select(biography2.title, from: "Related biography")
+        fill_in 'content_content_to_content', with: "#{biography1.id},#{biography2.id}"
         expect do
           click_on 'submit'
         end.not_to change { content.content_to_content.reload.count }

--- a/spec/helpers/cas/form_helper_spec.rb
+++ b/spec/helpers/cas/form_helper_spec.rb
@@ -17,8 +17,8 @@ describe Cas::FormHelper, type: :helper do
       @content = create(:content, section: @section)
 
       expect(helper.autocomplete_for_has_many).to match_array([
-        { id: related_content1.id, title: "#{related_content1.title} (Biography)" },
-        { id: related_content2.id, title: "#{related_content2.title} (Biography)" },
+        { value: related_content1.id, text: "#{related_content1.title} (Biography)" },
+        { value: related_content2.id, text: "#{related_content2.title} (Biography)" },
       ])
     end
   end

--- a/spec/helpers/cas/form_helper_spec.rb
+++ b/spec/helpers/cas/form_helper_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+describe Cas::FormHelper, type: :helper do
+  describe "#autocomplete_for_has_many" do
+    let(:site) { create(:site) }
+    let!(:related_section) { create(:section, :biography, site: site) }
+    # Why will it show these contents? Because the YAML file has specified that
+    # news has_many biography
+    let!(:related_content1) { create(:content, section: related_section) }
+    let!(:related_content2) { create(:content, section: related_section) }
+
+    before do
+      @section = create(:section, :news, site: site)
+    end
+
+    it "returns a hash with possible values" do
+      @content = create(:content, section: @section)
+
+      expect(helper.autocomplete_for_has_many).to match_array([
+        { id: related_content1.id, title: "#{related_content1.title} (Biography)" },
+        { id: related_content2.id, title: "#{related_content2.title} (Biography)" },
+      ])
+    end
+  end
+end

--- a/spec/lib/cas/section_config_spec.rb
+++ b/spec/lib/cas/section_config_spec.rb
@@ -84,6 +84,15 @@ module Cas
         end
       end
 
+      context 'when a section has a field for an association' do
+        let(:field) { :biography }
+
+        it 'returns true' do
+          form_has_field = subject.form_has_field?(field)
+          expect(form_has_field).to eq true
+        end
+      end
+
       context 'when field has configurations' do
         let(:slug) { 'agenda' }
         let(:field) { :date }

--- a/spec/test_app/config/environments/test.rb
+++ b/spec/test_app/config/environments/test.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
   config.action_controller.perform_caching = false
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = true
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false


### PR DESCRIPTION
We want to be able to associate a content with another. We don't have a good way
of doing that.

This commit adds the configuration to cas.yml and its documentation, and adds an
input that looks like one for setting `tags`, with autocomplete.